### PR TITLE
feat: 詳細画面の日付・削除ボタンをヘッダーに移動、共有ボタンを右下に移動

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,16 @@ jobs:
 
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: lint
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "^26.0"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/IceImageMemo/DetailView.swift
+++ b/IceImageMemo/DetailView.swift
@@ -54,31 +54,37 @@ struct DetailView<VM: DetailViewModel>: View {
                                 )
                             }
                         }
+
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            ShareLink(
+                                item: ShareableUIImage(uiImage: uiImage),
+                                preview: SharePreview(
+                                    "",
+                                    image: Image(uiImage: uiImage)
+                                )
+                            ) {
+                                Image(systemName: "square.and.arrow.up")
+                                    .font(.title2)
+                                    .foregroundStyle(.primary)
+                                    .padding(16)
+                                    .background(.ultraThinMaterial, in: Circle())
+                            }
+                            .padding(.trailing, 20)
+                            .padding(.bottom, 20)
+                        }
+                    }
                 }
                 .toolbar {
-                    ToolbarItemGroup(placement: .bottomBar) {
-                        ShareLink(
-                            item: ShareableUIImage(uiImage: uiImage),
-                            preview: SharePreview(
-                                "",
-                                image: Image(uiImage: uiImage)
-                            )
-                        ) {
-                            Image(systemName: "square.and.arrow.up")
-                                .foregroundStyle(.primary)
-                        }
-
-                        Spacer()
-
+                    ToolbarItem(placement: .principal) {
                         Text(vm.remainDate)
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.primary)
-                            .fixedSize(horizontal: true, vertical: false)
-                            .padding(.horizontal, 10)
-
-                        Spacer()
-
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
                         Button {
                             vm.isDelete = true
                         } label: {

--- a/IceImageMemo/DetailView.swift
+++ b/IceImageMemo/DetailView.swift
@@ -69,19 +69,19 @@ struct DetailView<VM: DetailViewModel>: View {
                                 if #available(iOS 26, *) {
                                     Image(systemName: "square.and.arrow.up")
                                         .font(.title2)
-                                        .foregroundStyle(.primary)
+                                        .foregroundStyle(.black)
                                         .padding(16)
                                         .glassEffect(in: .circle)
                                 } else {
                                     Image(systemName: "square.and.arrow.up")
                                         .font(.title2)
-                                        .foregroundStyle(.primary)
+                                        .foregroundStyle(.black)
                                         .padding(16)
                                         .background(.ultraThinMaterial, in: Circle())
                                 }
                             }
                             .padding(.trailing, 20)
-                            .padding(.bottom, 20)
+                            .padding(.bottom, 8)
                         }
                     }
                 }
@@ -89,16 +89,16 @@ struct DetailView<VM: DetailViewModel>: View {
                     ToolbarItem(placement: .principal) {
                         if #available(iOS 26, *) {
                             Text(vm.remainDate)
-                                .font(.subheadline)
-                                .fontWeight(.medium)
+                                .font(.headline)
+                                .fontWeight(.semibold)
                                 .foregroundStyle(.primary)
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
                                 .glassEffect(in: .capsule)
                         } else {
                             Text(vm.remainDate)
-                                .font(.subheadline)
-                                .fontWeight(.medium)
+                                .font(.headline)
+                                .fontWeight(.semibold)
                                 .foregroundStyle(.primary)
                         }
                     }

--- a/IceImageMemo/DetailView.swift
+++ b/IceImageMemo/DetailView.swift
@@ -69,14 +69,14 @@ struct DetailView<VM: DetailViewModel>: View {
                                 if #available(iOS 26, *) {
                                     Image(systemName: "square.and.arrow.up")
                                         .font(.title2)
-                                        .foregroundStyle(.black)
-                                        .padding(16)
+                                        .foregroundStyle(.white)
+                                        .frame(width: 52, height: 52)
                                         .glassEffect(in: .circle)
                                 } else {
                                     Image(systemName: "square.and.arrow.up")
                                         .font(.title2)
-                                        .foregroundStyle(.black)
-                                        .padding(16)
+                                        .foregroundStyle(.primary)
+                                        .frame(width: 52, height: 52)
                                         .background(.ultraThinMaterial, in: Circle())
                                 }
                             }

--- a/IceImageMemo/DetailView.swift
+++ b/IceImageMemo/DetailView.swift
@@ -70,7 +70,7 @@ struct DetailView<VM: DetailViewModel>: View {
                                     .font(.title2)
                                     .foregroundStyle(.primary)
                                     .padding(16)
-                                    .background(.ultraThinMaterial, in: Circle())
+                                    .glassEffect(in: .circle)
                             }
                             .padding(.trailing, 20)
                             .padding(.bottom, 20)
@@ -83,6 +83,9 @@ struct DetailView<VM: DetailViewModel>: View {
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(.primary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .glassEffect(in: .capsule)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {

--- a/IceImageMemo/DetailView.swift
+++ b/IceImageMemo/DetailView.swift
@@ -66,11 +66,19 @@ struct DetailView<VM: DetailViewModel>: View {
                                     image: Image(uiImage: uiImage)
                                 )
                             ) {
-                                Image(systemName: "square.and.arrow.up")
-                                    .font(.title2)
-                                    .foregroundStyle(.primary)
-                                    .padding(16)
-                                    .glassEffect(in: .circle)
+                                if #available(iOS 26, *) {
+                                    Image(systemName: "square.and.arrow.up")
+                                        .font(.title2)
+                                        .foregroundStyle(.primary)
+                                        .padding(16)
+                                        .glassEffect(in: .circle)
+                                } else {
+                                    Image(systemName: "square.and.arrow.up")
+                                        .font(.title2)
+                                        .foregroundStyle(.primary)
+                                        .padding(16)
+                                        .background(.ultraThinMaterial, in: Circle())
+                                }
                             }
                             .padding(.trailing, 20)
                             .padding(.bottom, 20)
@@ -79,13 +87,20 @@ struct DetailView<VM: DetailViewModel>: View {
                 }
                 .toolbar {
                     ToolbarItem(placement: .principal) {
-                        Text(vm.remainDate)
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.primary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .glassEffect(in: .capsule)
+                        if #available(iOS 26, *) {
+                            Text(vm.remainDate)
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .foregroundStyle(.primary)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .glassEffect(in: .capsule)
+                        } else {
+                            Text(vm.remainDate)
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .foregroundStyle(.primary)
+                        }
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {


### PR DESCRIPTION
## Summary
- `remainDate`（日付ラベル）をボトムバーから `.principal` ToolbarItem としてナビゲーションヘッダー中央に移動
- 削除ボタン（ゴミ箱アイコン）をボトムバーから `.topBarTrailing` としてヘッダー右端に移動
- 共有ボタンをボトムバーから画面右下のフローティングボタン（`.ultraThinMaterial` 背景の円形）に移動
- BottomBar ToolbarItemGroup を削除

## Test plan
- [ ] 詳細画面を開いて、ヘッダー中央に日付ラベルが表示されること
- [ ] ヘッダー右端にゴミ箱アイコンが表示されること
- [ ] ゴミ箱タップで削除確認アラートが表示され、削除が正常に動作すること
- [ ] 画面右下に共有ボタンが表示されること
- [ ] 共有ボタンタップで ShareSheet が開くこと
- [ ] ピンチイン/アウト・ダブルタップ・ドラッグのジェスチャーが引き続き正常に動作すること

Notion チケット: https://www.notion.so/34be1b0e884d81eaad1cc31a61e714f4

🤖 Generated with [Claude Code](https://claude.com/claude-code)