### PR TITLE
fix: カメラ縦向き固定と共有ボタンの視認性改善

### DIFF
--- a/IceImageMemo/CameraService.swift
+++ b/IceImageMemo/CameraService.swift
@@ -44,11 +44,9 @@ final class CameraServiceImpl: NSObject, CameraService {
             .builtInWideAngleCamera,
         ]
 
-        let mediaType: AVMediaType = .video
-
         let discovery = AVCaptureDevice.DiscoverySession(
             deviceTypes: deviceTypes,
-            mediaType: mediaType,
+            mediaType: .video,
             position: .back
         )
 
@@ -79,6 +77,10 @@ final class CameraServiceImpl: NSObject, CameraService {
         }
         if session.canAddOutput(photoOutput) {
             session.addOutput(photoOutput)
+        }
+        if let connection = photoOutput.connection(with: .video),
+           connection.isVideoRotationAngleSupported(90) {
+            connection.videoRotationAngle = 90
         }
         session.commitConfiguration()
     }

--- a/IceImageMemo/CameraService.swift
+++ b/IceImageMemo/CameraService.swift
@@ -4,151 +4,151 @@ import SwiftUI
 import UIKit
 
 protocol CameraService {
-    var session: AVCaptureSession { get }
-    var photoPublisher: AnyPublisher<Data, Never> { get }
-    func configure() async
-    func startRunning()
-    func stopRunning()
-    func capturePhoto()
+  var session: AVCaptureSession { get }
+  var photoPublisher: AnyPublisher<Data, Never> { get }
+  func configure() async
+  func startRunning()
+  func stopRunning()
+  func capturePhoto()
 }
 
 final class CameraServiceImpl: NSObject, CameraService {
-    var session = AVCaptureSession()
-    private let sessionQueue = DispatchQueue(label: "camera.session.queue")
-    private var deviceInput: AVCaptureDeviceInput?
-    private let photoOutput = AVCapturePhotoOutput()
-    private let photoSubject = PassthroughSubject<Data, Never>()
-    var photoPublisher: AnyPublisher<Data, Never> {
-        photoSubject.eraseToAnyPublisher()
+  var session = AVCaptureSession()
+  private let sessionQueue = DispatchQueue(label: "camera.session.queue")
+  private var deviceInput: AVCaptureDeviceInput?
+  private let photoOutput = AVCapturePhotoOutput()
+  private let photoSubject = PassthroughSubject<Data, Never>()
+  var photoPublisher: AnyPublisher<Data, Never> {
+    photoSubject.eraseToAnyPublisher()
+  }
+
+  func checkAuthorization() -> AVAuthorizationStatus {
+    AVCaptureDevice.authorizationStatus(for: .video)
+  }
+
+  func configure() async {
+    let status = checkAuthorization()
+    if status == .notDetermined {
+      let granted = await AVCaptureDevice.requestAccess(for: .video)
+      guard granted else { return }
     }
+    guard AVCaptureDevice.authorizationStatus(for: .video) == .authorized else { return }
 
-    func checkAuthorization() -> AVAuthorizationStatus {
-        AVCaptureDevice.authorizationStatus(for: .video)
+    session.beginConfiguration()
+    session.sessionPreset = .photo
+
+    let deviceTypes: [AVCaptureDevice.DeviceType] = [
+      .builtInTripleCamera,
+      .builtInDualWideCamera,
+      .builtInDualCamera,
+      .builtInWideAngleCamera,
+    ]
+
+    let discovery = AVCaptureDevice.DiscoverySession(
+      deviceTypes: deviceTypes,
+      mediaType: .video,
+      position: .back
+    )
+
+    let devices = discovery.devices
+
+    if let device =
+      devices.first(where: { $0.deviceType == .builtInTripleCamera }) ??
+      devices.first(where: { $0.deviceType == .builtInDualWideCamera }) ??
+      devices.first(where: { $0.deviceType == .builtInDualCamera }) ??
+      devices.first(where: { $0.deviceType == .builtInWideAngleCamera }) {
+      do {
+        let input = try AVCaptureDeviceInput(device: device)
+        if session.canAddInput(input) {
+          session.addInput(input)
+          deviceInput = input
+
+          try device.lockForConfiguration()
+          if let switchOverFactor = device.virtualDeviceSwitchOverVideoZoomFactors.first {
+            device.videoZoomFactor = CGFloat(switchOverFactor.floatValue)
+          } else {
+            device.videoZoomFactor = 1.0
+          }
+          device.unlockForConfiguration()
+        }
+      } catch {
+        print("Input error:", error)
+      }
     }
-
-    func configure() async {
-        let status = checkAuthorization()
-        if status == .notDetermined {
-            let granted = await AVCaptureDevice.requestAccess(for: .video)
-            guard granted else { return }
-        }
-        guard AVCaptureDevice.authorizationStatus(for: .video) == .authorized else { return }
-
-        session.beginConfiguration()
-        session.sessionPreset = .photo
-
-        let deviceTypes: [AVCaptureDevice.DeviceType] = [
-            .builtInTripleCamera,
-            .builtInDualWideCamera,
-            .builtInDualCamera,
-            .builtInWideAngleCamera,
-        ]
-
-        let discovery = AVCaptureDevice.DiscoverySession(
-            deviceTypes: deviceTypes,
-            mediaType: .video,
-            position: .back
-        )
-
-        let devices = discovery.devices
-
-        if let device =
-            devices.first(where: { $0.deviceType == .builtInTripleCamera }) ??
-            devices.first(where: { $0.deviceType == .builtInDualWideCamera }) ??
-            devices.first(where: { $0.deviceType == .builtInDualCamera }) ??
-            devices.first(where: { $0.deviceType == .builtInWideAngleCamera }) {
-            do {
-                let input = try AVCaptureDeviceInput(device: device)
-                if session.canAddInput(input) {
-                    session.addInput(input)
-                    deviceInput = input
-
-                    try device.lockForConfiguration()
-                    if let switchOverFactor = device.virtualDeviceSwitchOverVideoZoomFactors.first {
-                        device.videoZoomFactor = CGFloat(switchOverFactor.floatValue)
-                    } else {
-                        device.videoZoomFactor = 1.0
-                    }
-                    device.unlockForConfiguration()
-                }
-            } catch {
-                print("Input error:", error)
-            }
-        }
-        if session.canAddOutput(photoOutput) {
-            session.addOutput(photoOutput)
-        }
-        if let connection = photoOutput.connection(with: .video),
-           connection.isVideoRotationAngleSupported(90) {
-            connection.videoRotationAngle = 90
-        }
-        session.commitConfiguration()
+    if session.canAddOutput(photoOutput) {
+      session.addOutput(photoOutput)
     }
-
-    func startRunning() {
-        sessionQueue.async {
-            if !self.session.isRunning {
-                self.session.startRunning()
-            }
-        }
+    if let connection = photoOutput.connection(with: .video),
+       connection.isVideoRotationAngleSupported(90) {
+      connection.videoRotationAngle = 90
     }
+    session.commitConfiguration()
+  }
 
-    func stopRunning() {
-        sessionQueue.async {
-            if self.session.isRunning {
-                self.session.stopRunning()
-            }
-        }
+  func startRunning() {
+    sessionQueue.async {
+      if !self.session.isRunning {
+        self.session.startRunning()
+      }
     }
+  }
 
-    func capturePhoto() {
-        let settings = AVCapturePhotoSettings()
-        photoOutput.capturePhoto(with: settings, delegate: self)
+  func stopRunning() {
+    sessionQueue.async {
+      if self.session.isRunning {
+        self.session.stopRunning()
+      }
     }
+  }
+
+  func capturePhoto() {
+    let settings = AVCapturePhotoSettings()
+    photoOutput.capturePhoto(with: settings, delegate: self)
+  }
 }
 
 extension CameraServiceImpl: AVCapturePhotoCaptureDelegate {
-    func photoOutput(_: AVCapturePhotoOutput,
-                     didFinishProcessingPhoto photo: AVCapturePhoto,
-                     error: Error?) {
-        if let error {
-            print("Photo capture error: \(error)")
-            return
-        }
-        if let data = photo.fileDataRepresentation() {
-            photoSubject.send(data)
-        }
+  func photoOutput(_: AVCapturePhotoOutput,
+                   didFinishProcessingPhoto photo: AVCapturePhoto,
+                   error: Error?) {
+    if let error {
+      print("Photo capture error: \(error)")
+      return
     }
+    if let data = photo.fileDataRepresentation() {
+      photoSubject.send(data)
+    }
+  }
 }
 
 final class CameraPreviewContainerView: UIView {
-    private let previewLayer: AVCaptureVideoPreviewLayer
-    init(session: AVCaptureSession) {
-        previewLayer = AVCaptureVideoPreviewLayer(session: session)
-        super.init(frame: .zero)
-        backgroundColor = .black
-        previewLayer.videoGravity = .resizeAspectFill
-        layer.addSublayer(previewLayer)
-    }
+  private let previewLayer: AVCaptureVideoPreviewLayer
+  init(session: AVCaptureSession) {
+    previewLayer = AVCaptureVideoPreviewLayer(session: session)
+    super.init(frame: .zero)
+    backgroundColor = .black
+    previewLayer.videoGravity = .resizeAspectFill
+    layer.addSublayer(previewLayer)
+  }
 
-    @available(*, unavailable)
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        previewLayer.frame = bounds
-        guard let connection = previewLayer.connection else { return }
-        connection.videoRotationAngle = 90
-    }
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    previewLayer.frame = bounds
+    guard let connection = previewLayer.connection else { return }
+    connection.videoRotationAngle = 90
+  }
 }
 
 struct CameraServiceView: UIViewRepresentable {
-    let session: AVCaptureSession
-    func makeUIView(context _: Context) -> CameraPreviewContainerView {
-        CameraPreviewContainerView(session: session)
-    }
+  let session: AVCaptureSession
+  func makeUIView(context _: Context) -> CameraPreviewContainerView {
+    CameraPreviewContainerView(session: session)
+  }
 
-    func updateUIView(_: CameraPreviewContainerView, context _: Context) {}
+  func updateUIView(_: CameraPreviewContainerView, context _: Context) {}
 }

--- a/IceImageMemo/DetailView.swift
+++ b/IceImageMemo/DetailView.swift
@@ -72,7 +72,7 @@ struct DetailView<VM: DetailViewModel>: View {
               ) {
                 Image(systemName: "square.and.arrow.up")
                   .font(.title2)
-                  .foregroundStyle(.white)
+                  .foregroundStyle(.primary)
                   .frame(width: 52, height: 52)
                   .glassEffect(in: .circle)
               }


### PR DESCRIPTION
## Summary
- **カメラ撮影画像を縦向きに固定**: `AVCapturePhotoOutput` の photo connection を 90° (portrait) 固定にし、端末を横にして撮影しても縦長画像として保存されるように修正 (`CameraService.swift`)。
- **詳細画面の共有ボタン色を修正**: アイコンが `.white` 固定でライトモードで見えなくなっていたのを `.primary` に変更し、ヘッダーと色を揃えた (`DetailView.swift`)。

## Test plan
- [ ] 実機（縦持ち）で撮影 → 縦長で保存されることを確認
- [ ] 実機を **左に 90°** 回転（landscapeLeft）で撮影 → 縦長で保存されることを確認
- [ ] 実機を **右に 90°** 回転（landscapeRight）で撮影 → 縦長で保存されることを確認
- [ ] 実機を **逆さ持ち**（portraitUpsideDown）で撮影 → 縦長で保存されることを確認
- [ ] プレビュー表示が引き続き縦のまま正常に表示される
- [ ] アルバム → 詳細画面を **ライトモード** で開く → 共有ボタンのアイコンが視認できる
- [ ] アルバム → 詳細画面を **ダークモード** で開く → 共有ボタンのアイコンが視認できる
- [ ] `make lint` がパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)